### PR TITLE
Get mapping specification from Python script

### DIFF
--- a/src/fair_mappings_schema/annotate_script.py
+++ b/src/fair_mappings_schema/annotate_script.py
@@ -19,7 +19,7 @@ Run this script by passing the URL to a script on GitHub like in:
 
 .. code-block:: console
 
-    $ python -m fair_mappings_schema.annotate_script https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/annotate_script.py
+    $ python -m fair_mappings_schema.annotate_script --url https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/annotate_script.py
     author:
       name: Charles Tapley Hoyt
       orcid: 0000-0003-4423-4370
@@ -56,16 +56,30 @@ __all__ = ["get_python_script"]
 
 def get_python_script(script_url: str) -> MappingSpecification:
     """Get a mapping specification from a package."""
-    owner, repo = _get_repository(script_url)
-    pyproject_toml_data = _get_pyproject_toml(owner, repo)
-    project = pyproject_toml_data["project"]
-    urls = pyproject_toml_data.get("urls", {})
-    documentation = urls.get("documentation") or urls.get("Documentation")
-    mapping_specification_dict = dict(
+    data = dict(
         content_url=script_url,
         # TODO add explicit way of saying it's code
         type=MappingSpecificationTypeEnum.other,
         mapping_method="Python script",
+    )
+    data.update(_get_package_data(script_url))
+    data.update(_get_script_data(script_url))
+    return MappingSpecification.model_validate(data)
+
+
+def _get_package_data(script_url: str, branch: str = "main") -> dict[str, Any]:
+    owner, repo = _get_repository(script_url)
+    pyproject_toml_url = (
+        f"https://github.com/{owner}/{repo}/raw/refs/heads/{branch}/pyproject.toml"
+    )
+    pyproject_toml_res = requests.get(pyproject_toml_url, timeout=5)
+    if pyproject_toml_res.status_code != 200:
+        return {}  # there's no package data
+    pyproject_toml_data = tomllib.loads(pyproject_toml_res.text)
+    project = pyproject_toml_data["project"]
+    urls = pyproject_toml_data.get("urls", {})
+    documentation = urls.get("documentation") or urls.get("Documentation")
+    return dict(
         name=project["name"],
         version=project.get("version"),
         description=project.get("description"),
@@ -73,8 +87,6 @@ def get_python_script(script_url: str) -> MappingSpecification:
         author=_get_person(project, "authors"),
         documentation=documentation,
     )
-    mapping_specification_dict.update(_get_script_data(script_url))
-    return MappingSpecification.model_validate(mapping_specification_dict)
 
 
 def _get_script_data(script_url: str) -> dict[str, Any]:
@@ -107,13 +119,6 @@ def _get_person(project: dict[str, Any], key: str) -> Person | None:
     return Person(name=name, orcid=orcid)
 
 
-def _get_pyproject_toml(owner: str, repo: str, branch: str = "main"):
-    url = f"https://github.com/{owner}/{repo}/raw/refs/heads/{branch}/pyproject.toml"
-    res = requests.get(url, timeout=5)
-    data = tomllib.loads(res.text)
-    return data
-
-
 def _get_repository(url: str) -> tuple[str, str]:
     """Get a mapping specification from a package."""
     if url.startswith("https://github.com/"):
@@ -128,18 +133,17 @@ def _get_repository(url: str) -> tuple[str, str]:
     return owner, repo
 
 
+TOML_PATTERN = re.compile(
+    r"^#\s/// script\s*\n"  # opening marker
+    r"((?:#[^\n]*\n)*?)"  # captured comment lines
+    r"#\s///\s*$",  # closing marker
+    re.MULTILINE,
+)
+
+
 def extract_script_toml(source: str) -> dict[str, Any] | None:
-    """
-    Extract the raw TOML string from a `# /// script` ... `# ///` block.
-    Returns the TOML text, or None if no such block is found.
-    """
-    pattern = re.compile(
-        r"^#\s/// script\s*\n"  # opening marker
-        r"((?:#[^\n]*\n)*?)"  # captured comment lines
-        r"#\s///\s*$",  # closing marker
-        re.MULTILINE,
-    )
-    match = pattern.search(source)
+    """Extract the raw TOML string from a `# /// script` ... `# ///` block."""
+    match = TOML_PATTERN.search(source)
     if not match:
         return None
 
@@ -159,25 +163,24 @@ DEMO_URLS = [
 ]
 
 
-def normalize_github_url(url: str) -> str:
-    """Clean a URL.
-
-    :param url:
-    :return: A URL with
-
-    >>> normalize_github_url("https://github.com/data-literacy-alliance/oerbservatory/blob/main/src/oerbservatory/sources/dalia.py")
-    'https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py'
-    """
+def fix_github_url(url: str) -> str:
+    """Ensure that a GitHub URL is downloadable."""
     return url.replace("/blob/", "/raw/refs/heads/")
 
 
 @click.command()
-@click.argument("url")
-def main(url: str) -> None:
+@click.option("--url", help="URL to a script on GitHub")
+def main(url: str | None) -> None:
     """Get mapping specification YAML from a URL to a packaged Python script on GitHub."""
-    url = normalize_github_url(url)
-    model = get_python_script(url)
-    click.echo(model_dump_yaml(model, exclude_none=True))
+    if url is not None:
+        url = fix_github_url(url)
+        model = get_python_script(url)
+        click.echo(model_dump_yaml(model, exclude_none=True))
+    else:
+        click.secho("Demo Mode, since no --url given", fg="green")
+        for url in DEMO_URLS:
+            model = get_python_script(url)
+            click.echo(model_dump_yaml(model, exclude_none=True))
 
 
 if __name__ == "__main__":

--- a/src/fair_mappings_schema/annotate_script.py
+++ b/src/fair_mappings_schema/annotate_script.py
@@ -13,7 +13,30 @@
 # name = "FAIR Mappings Schema"
 # ///
 
-"""Extract metadata from Python script."""
+"""Extract metadata from Python script.
+
+Run this script by passing the URL to a script on GitHub like in:
+
+.. code-block:: console
+
+    $ python -m fair_mappings_schema.annotate_script https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/annotate_script.py
+    author:
+      name: Charles Tapley Hoyt
+      orcid: 0000-0003-4423-4370
+      type: Person
+    content_url: https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/annotate_script.py
+    description: A script that generates metadata describing a Mapping Specification implemented
+      in a Python script. See discussion in https://github.com/mapping-commons/fair-mappings-schema/pull/10.
+    license: Apache-2.0
+    mapping_method: Python script
+    name: Python Metadata to FAIR Mappings Schema
+    object_source:
+      name: FAIR Mappings Schema
+    subject_source:
+      name: Python Metadata
+    type: other
+
+"""
 
 import re
 from typing import Any
@@ -130,7 +153,7 @@ def extract_script_toml(source: str) -> dict[str, Any] | None:
 
 
 DEMO_URLS = [
-    "https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/get_packaged_python_script.py",
+    "https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/annotate_script.py",
     "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py",
     "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py",
 ]

--- a/src/fair_mappings_schema/datamodel/__init__.py
+++ b/src/fair_mappings_schema/datamodel/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from .fair_mappings_schema import *
+from .fair_mappings_schema import *  # noqa:F403
 
 THIS_PATH = Path(__file__).parent
 

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -63,9 +63,9 @@ def _get_script_data(script_url: str) -> dict[str, Any]:
         return {}
     rv = dd.get("tool", {}).get("fair-mappings")
     if rv.get("author"):
-        if rv['author']['email']:
-            del rv['author']['email']  # TODO
-        rv['author'] = Person.model_validate(rv['author'])
+        if rv["author"]["email"]:
+            del rv["author"]["email"]  # TODO
+        rv["author"] = Person.model_validate(rv["author"])
     return rv
 
 
@@ -129,17 +129,33 @@ def extract_script_toml(source: str) -> dict[str, Any] | None:
     return tomllib.loads("\n".join(toml_lines))
 
 
-def _main():
-    # TODO make function that fixes URL to be raw
-    urls = [
-        "https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/get_packaged_python_script.py",
-        "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py",
-        "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py",
-    ]
-    for url in urls:
-        model = get_python_script(url)
-        click.echo(model_dump_yaml(model, exclude_none=True, exclude={"author.type"}) + "\n")
+DEMO_URLS = [
+    "https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/get_packaged_python_script.py",
+    "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py",
+    "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py",
+]
+
+
+def normalize_github_url(url: str) -> str:
+    """Clean a URL.
+
+    :param url:
+    :return: A URL with
+
+    >>> normalize_github_url("https://github.com/data-literacy-alliance/oerbservatory/blob/main/src/oerbservatory/sources/dalia.py")
+    'https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py'
+    """
+    return url.replace("/blob/", "/raw/refs/heads/")
+
+
+@click.command()
+@click.argument("url")
+def main(url: str) -> None:
+    """Get mapping specification YAML from a URL to a packaged Python script on GitHub."""
+    url = normalize_github_url(url)
+    model = get_python_script(url)
+    click.echo(model_dump_yaml(model, exclude_none=True))
 
 
 if __name__ == "__main__":
-    _main()
+    main()

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -1,3 +1,15 @@
+# /// script
+# [tool.fair-mappings]
+# name = "Python Metadata to FAIR Mappings Schema"
+# description = """A script that generates metadata describing a Mapping Specification implemented \
+# in a Python script. See discussion in https://github.com/mapping-commons/fair-mappings-schema/pull/10."""
+# author = { "name": "Charles Tapley Hoyt", "orcid": "0000-0003-4423-4370", "email": "cthoyt@gmail.com" }
+# [tool.fair-mappings.subject_source]
+# name = "Python Metadata"
+# [tool.fair-mappings.object_source]
+# name = "FAIR Mappings Schema"
+# ///
+
 """Extract metadata from Python script."""
 
 import re
@@ -110,6 +122,7 @@ def extract_script_toml(source: str) -> dict[str, Any] | None:
 def _main():
     # TODO make function that fixes URL to be raw
     urls = [
+        "https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/get_packaged_python_script.py",
         "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py",
         "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py",
     ]

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -1,0 +1,118 @@
+"""Extract metadata from Python script."""
+
+import re
+from typing import Any
+
+from fair_mappings_schema.datamodel.fair_mappings_schema_pydantic import (
+    MappingSpecification,
+    Person,
+    MappingSpecificationTypeEnum,
+)
+import click
+import requests
+from pystow.utils import model_dump_yaml
+import tomllib
+
+__all__ = ["get_python_script"]
+
+
+def get_python_script(script_url: str) -> MappingSpecification:
+    """Get a mapping specification from a package."""
+    owner, repo = _get_repository(script_url)
+    data = _get_pyproject_toml(owner, repo)
+    project = data["project"]
+    urls = data.get("urls", {})
+    documentation = urls.get("documentation") or urls.get("Documentation")
+    xxx = dict(
+        content_url=script_url,
+        # TODO add explicit way of saying it's code
+        type=MappingSpecificationTypeEnum.other,
+        mapping_method="Python script",
+        name=project["name"],
+        version=project["version"],
+        description=project.get("description"),
+        license=project.get("license"),
+        author=_get_person(project, "authors"),
+        documentation=documentation,
+    )
+    xxx.update(_get_script_data(script_url))
+    return MappingSpecification.model_validate(xxx)
+
+
+def _get_script_data(script_url: str) -> dict[str, Any]:
+    """Get a mapping specification from a package."""
+    res = requests.get(script_url, timeout=5)
+    res.raise_for_status()
+    dd = extract_script_toml(res.text)
+    return dd.get("tool", {}).get("fair-mappings")
+
+
+def _get_person(project: dict[str, Any], key: str) -> Person | None:
+    people = project.get(key)
+    if not people:
+        return None
+    person = people[0]
+    name = person["name"]
+    # TODO add email to person model
+    # TODO see if we can recognize ORCiD here more officially
+    orcid = person.get("orcid")
+    if orcid:
+        orcid = orcid.removeprefix("https://orcid.com")
+        orcid = orcid.removeprefix("http://orcid.com")
+    return Person(name=name, orcid=orcid)
+
+
+def _get_pyproject_toml(owner: str, repo: str, branch: str = "main"):
+    url = f"https://github.com/{owner}/{repo}/raw/refs/heads/{branch}/pyproject.toml"
+    res = requests.get(url, timeout=5)
+    data = tomllib.loads(res.text)
+    return data
+
+
+def _get_repository(url: str) -> tuple[str, str]:
+    """Get a mapping specification from a package."""
+    if url.startswith("https://github.com/"):
+        url = url.removeprefix("https://github.com/")
+    if url.startswith("http://github.com/"):
+        url = url.removeprefix("http://github.com/")
+
+    parts = url.split("/")
+    if len(parts) == 1:
+        raise ValueError(f"no repository given, just an owner: {url}")
+    owner, repo, *_ = parts
+    return owner, repo
+
+
+def extract_script_toml(source: str) -> dict[str, Any] | None:
+    """
+    Extract the raw TOML string from a `# /// script` ... `# ///` block.
+    Returns the TOML text, or None if no such block is found.
+    """
+    pattern = re.compile(
+        r"^#\s/// script\s*\n"  # opening marker
+        r"((?:#[^\n]*\n)*?)"  # captured comment lines
+        r"#\s///\s*$",  # closing marker
+        re.MULTILINE,
+    )
+    match = pattern.search(source)
+    if not match:
+        return None
+
+    # Strip the leading `# ` (or `#`) from every line
+    toml_lines = []
+    for line in match.group(1).splitlines():
+        # Remove exactly one leading `# ` or `#`
+        toml_lines.append(re.sub(r"^#( ?)", "", line))
+
+    return tomllib.loads("\n".join(toml_lines))
+
+
+def _main():
+    # TODO make function that fixes URL to be raw
+    better_url = "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py"
+    model = get_python_script(better_url)
+    click.echo(model_dump_yaml(model, exclude_none=True, exclude={"author.type"}))
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -3,7 +3,10 @@
 # name = "Python Metadata to FAIR Mappings Schema"
 # description = """A script that generates metadata describing a Mapping Specification implemented \
 # in a Python script. See discussion in https://github.com/mapping-commons/fair-mappings-schema/pull/10."""
-# author = { "name": "Charles Tapley Hoyt", "orcid": "0000-0003-4423-4370", "email": "cthoyt@gmail.com" }
+# [tool.fair-mappings.author]
+# name = "Charles Tapley Hoyt"
+# orcid = "0000-0003-4423-4370"
+# email = "cthoyt@gmail.com"
 # [tool.fair-mappings.subject_source]
 # name = "Python Metadata"
 # [tool.fair-mappings.object_source]
@@ -41,7 +44,7 @@ def get_python_script(script_url: str) -> MappingSpecification:
         type=MappingSpecificationTypeEnum.other,
         mapping_method="Python script",
         name=project["name"],
-        version=project["version"],
+        version=project.get("version"),
         description=project.get("description"),
         license=project.get("license"),
         author=_get_person(project, "authors"),

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -19,11 +19,11 @@ __all__ = ["get_python_script"]
 def get_python_script(script_url: str) -> MappingSpecification:
     """Get a mapping specification from a package."""
     owner, repo = _get_repository(script_url)
-    data = _get_pyproject_toml(owner, repo)
-    project = data["project"]
-    urls = data.get("urls", {})
+    pyproject_toml_data = _get_pyproject_toml(owner, repo)
+    project = pyproject_toml_data["project"]
+    urls = pyproject_toml_data.get("urls", {})
     documentation = urls.get("documentation") or urls.get("Documentation")
-    xxx = dict(
+    mapping_specification_dict = dict(
         content_url=script_url,
         # TODO add explicit way of saying it's code
         type=MappingSpecificationTypeEnum.other,
@@ -35,8 +35,8 @@ def get_python_script(script_url: str) -> MappingSpecification:
         author=_get_person(project, "authors"),
         documentation=documentation,
     )
-    xxx.update(_get_script_data(script_url))
-    return MappingSpecification.model_validate(xxx)
+    mapping_specification_dict.update(_get_script_data(script_url))
+    return MappingSpecification.model_validate(mapping_specification_dict)
 
 
 def _get_script_data(script_url: str) -> dict[str, Any]:
@@ -109,9 +109,13 @@ def extract_script_toml(source: str) -> dict[str, Any] | None:
 
 def _main():
     # TODO make function that fixes URL to be raw
-    better_url = "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py"
-    model = get_python_script(better_url)
-    click.echo(model_dump_yaml(model, exclude_none=True, exclude={"author.type"}))
+    urls = [
+        "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py",
+        "https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py",
+    ]
+    for url in urls:
+        model = get_python_script(url)
+        click.echo(model_dump_yaml(model, exclude_none=True, exclude={"author.type"}) + "\n")
 
 
 if __name__ == "__main__":

--- a/src/fair_mappings_schema/get_packaged_python_script.py
+++ b/src/fair_mappings_schema/get_packaged_python_script.py
@@ -59,7 +59,14 @@ def _get_script_data(script_url: str) -> dict[str, Any]:
     res = requests.get(script_url, timeout=5)
     res.raise_for_status()
     dd = extract_script_toml(res.text)
-    return dd.get("tool", {}).get("fair-mappings")
+    if not dd:
+        return {}
+    rv = dd.get("tool", {}).get("fair-mappings")
+    if rv.get("author"):
+        if rv['author']['email']:
+            del rv['author']['email']  # TODO
+        rv['author'] = Person.model_validate(rv['author'])
+    return rv
 
 
 def _get_person(project: dict[str, Any], key: str) -> Person | None:


### PR DESCRIPTION
This PR adds a script that retrieves metadata from a Python script in GitHub-based Python package. It implicitly defines the `[tool.fair-mappings]` metadata slot to include using [PEP 723](https://peps.python.org/pep-0723/) inline metadata and the project metadata in the package's `pyproject.toml`.

For the DALIA to OERbservatory conversion script at https://github.com/data-literacy-alliance/oerbservatory/blob/main/src/oerbservatory/sources/dalia.py, this produces the following YAML:

```yaml
author:
  name: Charles Tapley Hoyt
  type: Person
content_url: https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/dalia.py
description: 'Functionality in the OERbservatory Python package that converts from
  the external DALIA Interchange Format (DIF) to the OERbservatory''s internal data model.'
license: MIT
mapping_method: Python script
name: DALIA Interchange Format to OERbservatory
object_source:
  id: wikidata:Q139858018
  name: OERbservatory Data Model
subject_source:
  id: wikidata:Q139858013
  name: DALIA Interchange Format
type: other
version: 0.0.2-dev
```

Similarly, for the TeSS to OERbservatory conversion script at https://github.com/data-literacy-alliance/oerbservatory/blob/main/src/oerbservatory/sources/tess.py, this produces the following YAML:

```yaml
author:
  name: Charles Tapley Hoyt
  type: Person
content_url: https://github.com/data-literacy-alliance/oerbservatory/raw/refs/heads/main/src/oerbservatory/sources/tess.py
description: 'Functionality in the OERbservatory Python package that converts from
  the external ELIXIR Training eSupport System (TeSS) implicit data model to the OERbservatory''s internal data model.'
license: MIT
mapping_method: Python script
name: TeSS to OERbservatory
object_source:
  id: wikidata:Q139858018
  name: OERbservatory Data Model
subject_source:
  id: wikidata:Q109494708
  name: ELIXIR Training eSupport System
type: other
version: 0.0.2-dev
```

This script can even generate metadata about itself:

```yaml
author:
  name: Charles Tapley Hoyt
  orcid: 0000-0003-4423-4370
  type: Person
content_url: https://github.com/cthoyt/fair-mappings-schema/raw/refs/heads/software-description/src/fair_mappings_schema/get_packaged_python_script.py
description: A script that generates metadata describing a Mapping Specification implemented
  in a Python script. See discussion in https://github.com/mapping-commons/fair-mappings-schema/pull/10.
license: Apache-2.0
mapping_method: Python script
name: Python Metadata to FAIR Mappings Schema
object_source:
  name: FAIR Mappings Schema
subject_source:
  name: Python Metadata
type: other
```


> [!WARNING]  
> The script that's covered here can't be directly executed to do the mappings, it's just where the code that does the mapping is implemented. I don't think that we will ever be successful at representing how a script should be run - we'd just be re-inventing a general purpose programming language. I think that to be successful at giving metadata about an implementation of a mapping specification in a general purpose programming language, we should either be giving information about where is the code or the package that does it, and if possible, documentation on how to use it.


Questions:

- how do we propagate these into a mapping registry? In theory, we can point to a script by URL and then it should be possible to run this function to get the metadata.